### PR TITLE
t210: use DEFAULT MMC_DEV to get devnum dynamically instead

### DIFF
--- a/include/configs/p3450-0000.h
+++ b/include/configs/p3450-0000.h
@@ -51,7 +51,7 @@
 #define FITIMAGE_ENV_SETTINGS \
 	"mmcdev=0\0" \
 	"mmcpart=1\0" \
-	"devnum=1\0" \
+	"devnum=" DEFAULT_MMC_DEV "\0" \
 	"fitpart=1\0" \
 	"prefix=/boot\0" \
 	"mmcfit_name=fitImage\0" \


### PR DESCRIPTION
 of hard coded value that's works only with Jetson Nano DevKit
 (SDcard version).

Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
