### PR TITLE
tools/fit_check_sign.c: Minor update in the usage function.

### DIFF
--- a/tools/fit_check_sign.c
+++ b/tools/fit_check_sign.c
@@ -25,9 +25,10 @@
 
 void usage(char *cmdname)
 {
-	fprintf(stderr, "Usage: %s -f fit file -k key file\n"
+	fprintf(stderr, "Usage: %s -f fit file -k key file -c config name\n"
 			 "          -f ==> set fit file which should be checked'\n"
-			 "          -k ==> set key file which contains the key'\n",
+			 "          -k ==> set key file which contains the key'\n"
+			 "          -c ==> set the configuration name'\n",
 		cmdname);
 	exit(EXIT_FAILURE);
 }


### PR DESCRIPTION
Add "-c" option to set the configuration name when
checking the FIT image signature.

Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
